### PR TITLE
Experimental removal of max file upload size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ RUN apt-get update \
 
 # Configure Nginx and apply fix for very long server names
 RUN echo "daemon off;" >> /etc/nginx/nginx.conf \
- && sed -i 's/^http {/&\n    server_names_hash_bucket_size 128;/g' /etc/nginx/nginx.conf
+ && sed -i 's/^http {/&\n    server_names_hash_bucket_size 128;/g' /etc/nginx/nginx.conf \
+ && sed -i 's/^http {/&\n    client_max_body_size 0;/g' /etc/nginx/nginx.conf
 
 # Install Forego
 ADD https://github.com/jwilder/forego/releases/download/v0.16.1/forego /usr/local/bin/forego


### PR DESCRIPTION
This merge request removes the file upload size limit from nginx-proxy.

There are two things going on here. 

1) I've forked nginx-proxy from gregsymons, built this fork locally and verified that building today results in a docker image that runs as expected. This was not a foregone conclusion since the Dockerfile wgets in files from jwilder that may have changed in the 2 years since the last commit to gregsymons.

2) I've changed the nginx.conf file to allow any file upload size. I have done this in a new branch (this one), built the docker image locally and all seems well. 

I haven't tested with jupyter, only with rstudio.